### PR TITLE
update reencrypt for new ca cert

### DIFF
--- a/modules/cp4data_4.0/main.tf
+++ b/modules/cp4data_4.0/main.tf
@@ -497,6 +497,26 @@ resource "null_resource" "install_wsruntime" {
   ]
 }
 
+# Reencrypt route
+resource "null_resource" "reencrypt_route" {
+  
+  provisioner "local-exec" {
+    environment = {
+      KUBECONFIG = var.cluster_config_path
+    }
+    working_dir = "${path.module}/scripts/"
+    interpreter = ["/bin/bash", "-c"]
+    command = "./reencrypt_route.sh ${var.cpd_project_name}"
+  }
+
+  depends_on = [
+    var.portworx_is_ready,
+    null_resource.prereqs_checkpoint,
+    null_resource.bedrock_zen_operator,
+  ]
+}
+
+
 data "external" "get_endpoints" {
   count = var.enable ? 1 : 0
 

--- a/modules/cp4data_4.0/scripts/reencrypt_route.sh
+++ b/modules/cp4data_4.0/scripts/reencrypt_route.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 NAMESPACE=$1
-nginxpod=$(oc -n $NAMESPACE get pod -l component=ibm-nginx -o jsonpath='{.items[0].metadata.name}')
-oc -n $NAMESPACE cp $nginxpod:/etc/nginx/config/ssl/cert.crt /tmp/cert.crt || exit 1
-oc -n $NAMESPACE delete route ${NAMESPACE}-cpd
-oc -n $NAMESPACE create route reencrypt ${NAMESPACE}-cpd --service=ibm-nginx-svc --port=ibm-nginx-https-port --dest-ca-cert=/cert.crt
+oc -n $NAMESPACE extract secret/ibm-nginx-internal-tls-ca --keys=cert.crt --to=/tmp > /dev/null
+oc -n $NAMESPACE delete route cpd
+oc -n $NAMESPACE create route reencrypt cpd --service=ibm-nginx-svc --port=ibm-nginx-https-port --dest-ca-cert=/tmp/cert.crt
 rm /tmp/cert.crt


### PR DESCRIPTION
Updates - brings back in call to `reencrypt_route.sh` from `main.tf` in the cp4data_4.

Changes `reencrypt_route.sh` to use new CA certificate in 4.0.1 installs post October 9th release.